### PR TITLE
fix: --full-history to avoid all the time window filter

### DIFF
--- a/GitViz-CLI-README.md
+++ b/GitViz-CLI-README.md
@@ -30,8 +30,10 @@ You choose flags; output only includes requested blocks. No colors; minimal nois
 
 ## 2. Argument Forms
 
+### Boolean falgs:
 Boolean flags stand alone: `--all`, `--contributors`, etc.
 
+### Key-value pairs format:
 Every value‑taking flag accepts all forms:
 
 - Space: `--format json`
@@ -39,25 +41,28 @@ Every value‑taking flag accepts all forms:
 - Brackets: `--format[json]`
 - Some also accept the value as the next token.
 
-Time / range flags:
+### Time / range flags: Priority Order (Highest to Lowest):
+- `--full-history` → Overrides everything, uses entire repo history
+  - Example: `node gitviz-cli.js --commit-frequency --days 5 --since 2025-08-14 --until 2025-08-20 --full-history`, all filters got ignored, from beginning to the today
+- `--since`/`--until` → Overrides --days
+  - Example: `node gitviz-cli.js --commit-frequency --days 5 --since 2025-08-14 --until 2025-08-20`, days got ignored.
+- `--days` → Only works if none of the above are specified
+  - Example: `node gitviz-cli.js --commit-frequency --days 5`, 5 days back from today.
+- Default 30-day window → Fallback when nothing is specified
 
-- `--since YYYY-MM-DD`
-- `--until YYYY-MM-DD`
-- `--days N` (backward sliding window; materialized into since/until)
-- `--full-history` (ignore default 30‑day window)
 
-Scope / filter:
+### Scope / filter:
 
 - `--repo <path>` (default `.`)
 - `--all` (all refs)
 - `--author <pattern>` (git author regex)
 
-Output selection:
+### Output selection:
 
 - `--format json` or `--json`
 - `--meta` (add meta section)
 
-Help: `-h` / `--help`
+### Help: `-h` / `--help`
 
 ---
 

--- a/gitviz-cli.js
+++ b/gitviz-cli.js
@@ -467,10 +467,10 @@ function branchStats(repo, branches, cfg) {
             authorList = [];
         try {
             commits = parseInt(runGit(["rev-list", b.branch, "--count", ...t], repo).trim(), 10) || 0;
-        } catch {}
+        } catch { }
         try {
             merges = parseInt(runGit(["rev-list", b.branch, "--merges", "--count", ...t], repo).trim(), 10) || 0;
-        } catch {}
+        } catch { }
         try {
             const fmt = "%an%x01%ae"; // name + email
             const args = ["log", b.branch, `--pretty=format:${fmt}`, ...t];
@@ -490,7 +490,7 @@ function branchStats(repo, branches, cfg) {
                 });
             authors = set.size;
             authorList = Array.from(set).sort();
-        } catch {}
+        } catch { }
         return { branch: b.branch, commits, merges, authors, authorList };
     });
 }
@@ -616,6 +616,10 @@ function outputPlain(sections) {
         args.since = fmtDate(start);
     }
     const firstDate = repoFirstCommitDate(args.repo);
+    if (args.fullHistory){
+        args.since = firstDate
+        args.until = new Date().toISOString().split("T")[0]; // "2025-08-21"
+    }
     const repoAgeDays = firstDate ? diffDaysInclusive(firstDate, fmtDate(new Date())) : 0;
 
     // Decide which data sets are needed


### PR DESCRIPTION
## Priority Order (Highest to Lowest):
- `--full-history` → Overrides everything, uses entire repo history
  - Example: `node gitviz-cli.js --commit-frequency --days 5 --since 2025-08-14 --until 2025-08-20 --full-history`, all filters got ignored, from beginning to the today
- `--since`/`--until` → Overrides --days
  - Example: `node gitviz-cli.js --commit-frequency --days 5 --since 2025-08-14 --until 2025-08-20`, days got ignored.
- `--days` → Only works if none of the above are specified
  - Example: `node gitviz-cli.js --commit-frequency --days 5`, 5 days back from today.
- Default 30-day window → Fallback when nothing is specified
